### PR TITLE
Get rid of Behavior interfaces.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -144,9 +144,9 @@ gulp.task('generate:imports-map', ['parse'], function() {
 gulp.task('generate:elements', ['parse'], function() {
   return StreamFromArray(global.parsed,{objectMode: true})
    .on('data', function(item) {
-     console.log("Data: ", item.is, item.type)
-     var e = item.type == 'behavior'? '' : 'Element';
-     parseTemplate('Element', item, item.is, 'element/', e + '.java');
+     if (!helpers.isBehavior(item)) {
+       parseTemplate('Element', item, item.is, 'element/', 'Element.java');
+     }
    })
 });
 

--- a/template/Element.template
+++ b/template/Element.template
@@ -11,10 +11,7 @@ import com.google.gwt.core.client.js.JsType;
  * <%= getDescription(' ') %>
  */
 @JsType
-public interface <%= elementClassName() %> <%= baseClassName() %> {
-    /**
-     * AUTO-GENERATED CODE, DO NOT EDIT !!!
-     */
+public interface <%= elementClassName() %> extends HTMLElement {
 
     public static final String TAG = "<%= name %>";
     public static final String SRC = "<%= path %>";
@@ -23,27 +20,40 @@ public interface <%= elementClassName() %> <%= baseClassName() %> {
     /**
      * <%= getDescription('     ', atribute) %>
      *
+     * JavaScript Info:
      * @attribute <%= attribute.name %>
      * @type <%= attribute.type %>
      */
     @JsProperty <%= computeType(attribute.type) %> <%= computeGetterWithPrefix(attribute) %>();
     @JsProperty void <%= computeSetterWithPrefix(attribute) %>(<%= computeType(attribute.type) %> value);
 <% }); %>
-<% if (hasProperties()) _.forEach(properties, function(item){ if (isBehavior() || !item.isBehavior) if (item.type != 'Function') { %>
+<% if (hasProperties()) _.forEach(properties, function(item){ if (item.type != 'Function') { %>
     /**
      * <%= getDescription('     ', item) %>
      *
+     * JavaScript Info:
      * @property <%= item.name %>
      * @type <%= item.type %>
+     * <%= item.isBehavior ? ('@behavior ' + item.behavior ) : ''%>
      */
     @JsProperty <%= computeType(item.type) %> <%= computeGetterWithPrefix(item) %>();
+    /**
+     * <%= getDescription('     ', item) %>
+     *
+     * JavaScript Info:
+     * @property <%= item.name %>
+     * @type <%= item.type %>
+     * <%= item.isBehavior ? ('@behavior ' + item.behavior ) : ''%>
+     */
     @JsProperty void <%= computeSetterWithPrefix(item) %>(<%= computeType(item.type) %> value);
   <% } else { %>
     /**
      * <%= getDescription('     ', item) %>
      *
+     * JavaScript Info:
      * @method <%= item.name %><% if (!!item.params) _.forEach(item.params, function(param) { %>
      * @param {<%= param.type %>} <%= param.name %> <%= param.description %> <% }); %>
+     * <%= item.isBehavior ? ('@behavior ' + item.behavior ) : ''%>
      */
     void <%= item.name %>(<%= typedParamsString(item) %>);
 <% }}); %>

--- a/template/ElementEvent.template
+++ b/template/ElementEvent.template
@@ -11,9 +11,6 @@ import com.google.gwt.core.client.js.JsType;
  */
 @JsType
 public interface <%= camelCase(name) %>Event extends Event {
-	/**
-	 * AUTO-GENERATED CODE, DO NOT EDIT !!!
-	 */
 
     static final String NAME = "<%= computeName(name) %>";
 <% if (hasParams()) { %>

--- a/template/Widget.template
+++ b/template/Widget.template
@@ -14,10 +14,6 @@ import com.google.gwt.core.client.JavaScriptObject;
  * <%= getDescription(' ') %>
  */
 public class <%= className() %> extends <%= baseWidgetName() %> {
-	/**
-	 * AUTO-GENERATED CODE, DO NOT EDIT !!!
-	 */
-
     /**
      * Default Constructor.
      */
@@ -60,6 +56,7 @@ public class <%= className() %> extends <%= baseWidgetName() %> {
     /**
      * <%= getDescription('     ', atribute) %>
      *
+     * JavaScript Info:
      * @attribute <%= attribute.name %>
      * @type <%= attribute.type %>
      */
@@ -77,6 +74,7 @@ public class <%= className() %> extends <%= baseWidgetName() %> {
     /**
      * <%= getDescription('     ', item) %>
      *
+     * JavaScript Info:
      * @property <%= item.name %>
      * @type <%= item.type %>
      * <%= item.isBehavior ? ('@behavior ' + item.behavior ) : ''%>
@@ -91,6 +89,7 @@ public class <%= className() %> extends <%= baseWidgetName() %> {
     /**
      * <%= getDescription('     ', item) %>
      *
+     * JavaScript Info:
      * @method <%= item.name %><% if (!!item.params) _.forEach(item.params, function(param) { %>
      * @param {<%= param.type %>} <%= param.name %> <%= param.description %> <% }); %>
      * <%= item.isBehavior ? ('@behavior ' + item.behavior ) : ''%>
@@ -103,6 +102,9 @@ public class <%= className() %> extends <%= baseWidgetName() %> {
 <% if (hasEvents()) _.forEach(events, function(event){ %>
     /**
      * <%= getDescription('     ', event) %>
+     *
+     * JavaScript Info:
+     * @event <%= event.name %>     
      */
     public HandlerRegistration add<%= camelCase(event.name) %>Handler(<%= camelCase(event.name) %>EventHandler handler) {
         return addHandler(handler, <%= camelCase(event.name) %>Event.TYPE);

--- a/template/WidgetEvent.template
+++ b/template/WidgetEvent.template
@@ -8,9 +8,6 @@ import com.google.gwt.core.client.JavaScriptObject;
  * <%= getDescription(' ') %>
  */
 public class <%= camelCase(name) %>Event extends GwtEvent<<%= camelCase(name) %>EventHandler> {
-	/**
-	 * AUTO-GENERATED CODE, DO NOT EDIT !!!
-	 */
 
     public static Type<<%= camelCase(name) %>EventHandler> TYPE = new Type<<%= camelCase(name) %>EventHandler>();
 

--- a/template/WidgetEventHandler.template
+++ b/template/WidgetEventHandler.template
@@ -7,8 +7,6 @@ import com.google.gwt.event.shared.EventHandler;
  *
  */
 public interface <%= camelCase(name) %>EventHandler extends EventHandler {
-	/**
-	 * AUTO-GENERATED CODE, DO NOT EDIT
-	 */
+
     void on<%= camelCase(name) %>(<%= camelCase(name) %>Event event);
 }


### PR DESCRIPTION
Now all Elements have hardcoded all behavior methods and properties
so as the user does not care about the js hierarchy which is confusing
in java.
Removing GENERATED CODE warnings so as they dont go to java doc site.
Adding documentation to setters.
Maintaining in doc JS annotations for reference

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/metathesis/3)
<!-- Reviewable:end -->
